### PR TITLE
Update vitals form to display date vs last_updated

### DIFF
--- a/interface/forms/vitals/report.php
+++ b/interface/forms/vitals/report.php
@@ -46,13 +46,23 @@ function vitals_report($pid, $encounter, $cols, $id, $print = true)
                 $key == "id" || $key == "pid" ||
                 $key == "user" || $key == "groupname" ||
                 $key == "authorized" || $key == "activity" ||
-                $key == "date" || $value == "" ||
+                $key == "last_updated" || $value == "" ||
                 $value == "0000-00-00 00:00:00" || $value == "0.0"
             ) {
                 // skip certain data
                 continue;
             }
-
+    // Date display with formatting
+    if ($key == "date") {
+    $formatted_date = date("m/d/Y g:i A", strtotime($value));
+    $vitals .= "<td><div class='font-weight-bold d-inline-block'>" . xlt("Date") . ": </div></td><td><div class='text' style='display:inline-block'>" . text($formatted_date) . "</div></td>";
+    $count++;
+    if ($count == $cols) {
+        $count = 0;
+        $vitals .= "</tr><tr>\n";
+    }
+    continue;
+}
             if ($value == "on") {
                 $value = "yes";
             }


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #8221 

#### Short description of what this resolves:

When creating patient report (Patient --> Report), and selecting vitals, the data for time is pulled from `last_updated` column which may be clinically not relevant to the encounter if it was edited or entered at later times. Also, unlike `date`, `last_updated` can not be adjusted from the web interface. By replacing  `last_updated` with `date`:
- the `date` will the same as `last_updated` if not changed
- it can be adjusted with the date time picker
- It is more clinically relevant to the time vital sign actually recorded


![image](https://github.com/user-attachments/assets/84a00c91-ea13-41a4-b146-815dbea30d4e)
In the above example teh encounter is in 2014 but becuase vital signs were updated recently it says 2025

with the proposed changes the date can be set using the time / date picker to the more clinically relevant time and date 
![image](https://github.com/user-attachments/assets/e8542948-4b62-439c-89c3-80f16efa05e9)
 
#### Changes proposed in this pull request:
This PR edits one file only `interface/forms/vitals/report.php`

When pulling data from the vital signs table I would like to skip last_updated and keep date. Also I would like ot formate the date.

#### Does your code include anything generated by an AI Engine? Yes


